### PR TITLE
ci: auto-publish on v4 merge

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,10 +1,20 @@
 name: Publish to npm
+
 on:
+  push:
+    branches: [v4]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.gitignore'
+      - '.npmignore'
   workflow_dispatch:
 
 permissions:
-  contents: write  # Required for creating releases and tags
-  id-token: write  # Required for requesting the JWT
+  contents: write  # Required for creating releases, tags, and pushing version bumps
+  id-token: write  # Required for OIDC npm provenance
   packages: write
 
 jobs:
@@ -13,6 +23,32 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Detect dependabot merge
+        id: dependabot
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          if echo "$COMMIT_MSG" | grep -q 'dependabot/'; then
+            echo "is_dependabot=true" >> $GITHUB_OUTPUT
+            echo "Dependabot merge detected"
+          else
+            echo "is_dependabot=false" >> $GITHUB_OUTPUT
+            echo "Not a dependabot merge"
+          fi
+
+      - name: Bump patch version for dependabot
+        if: steps.dependabot.outputs.is_dependabot == 'true'
+        run: npm version patch --no-git-tag-version
+
+      - name: Commit and push dependabot version bump
+        if: steps.dependabot.outputs.is_dependabot == 'true'
+        run: |
+          NEW_VERSION=$(jq -r '.version' package.json)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to v${NEW_VERSION} [dependabot]"
+          git push
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -30,13 +66,13 @@ jobs:
           VERSION=$(jq -r '.version' package.json)
           echo "package=$PACKAGE_NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          
+
           if npm view $PACKAGE_NAME@$VERSION > /dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "⚠️  Version $VERSION already exists on npm"
+            echo "Version $VERSION already exists on npm"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "✓ Version $VERSION is new, will publish"
+            echo "Version $VERSION is new, will publish"
           fi
 
       - name: Publish to npm
@@ -51,14 +87,14 @@ jobs:
           name: Release v${{ steps.check.outputs.version }}
           body: |
             ## Quant TypeScript SDK v${{ steps.check.outputs.version }}
-            
+
             Auto-generated from unified API specification.
-            
+
             **Install:**
             ```bash
             npm install ${{ steps.check.outputs.package }}@${{ steps.check.outputs.version }}
             ```
-            
+
             **Changes:** See commit history
           draft: false
           prerelease: false
@@ -67,13 +103,16 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## 📦 Publish Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Publish Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Package:** ${{ steps.check.outputs.package }}" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ steps.check.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.check.outputs.exists }}" == "true" ]; then
-            echo "**Status:** ⚠️  Already published (skipped)" >> $GITHUB_STEP_SUMMARY
+            echo "**Status:** Already published (skipped)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "**Status:** ✅ Published successfully" >> $GITHUB_STEP_SUMMARY
+            echo "**Status:** Published successfully" >> $GITHUB_STEP_SUMMARY
             echo "**npm:** https://www.npmjs.com/package/${{ steps.check.outputs.package }}/v/${{ steps.check.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.dependabot.outputs.is_dependabot }}" == "true" ]; then
+            echo "**Dependabot:** Patch version was auto-bumped" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## Summary

- Publish workflow now triggers automatically on push to v4 (instead of manual dispatch only)
- Detects dependabot merges via commit message and auto-bumps the patch version (e.g. 4.11.0 → 4.11.1)
- Portal/SDK PRs publish as-is since the version is already set by the generation pipeline
- `workflow_dispatch` retained as a manual fallback
- `paths-ignore` prevents publishing on workflow, docs, or metadata-only changes

## Notes

- **First merge:** This PR only changes `.github/**`, which is in `paths-ignore`, so merging it will NOT trigger a publish run. This is expected.
- **GITHUB_TOKEN re-trigger safety:** The dependabot version bump commit uses `GITHUB_TOKEN`, which does not re-trigger workflows. The duplicate-version check provides an additional safety net.
- **npm auth:** Uses OIDC (no secrets/tokens), matching the existing approach.

## Test plan

- [ ] Verify test workflow passes on this PR
- [ ] After merge, use `workflow_dispatch` to confirm the workflow runs correctly
- [ ] On next dependabot PR merge, verify patch bump + auto-publish works
- [ ] On next SDK PR merge, verify direct publish works